### PR TITLE
Add the list of escaped characters to the docs and clarify synopsis

### DIFF
--- a/lib/HTML/Escape.pm
+++ b/lib/HTML/Escape.pm
@@ -37,12 +37,15 @@ HTML::Escape - Extremely fast HTML escaping
 
     use HTML::Escape qw/escape_html/;
 
-    escape_html("<^o^>");
+    my $escaped = escape_html("<^o^>");
 
 =head1 DESCRIPTION
 
 This modules provides a function which escapes HTML's special characters. It
-performs a similar function to PHP's htmlspecialchars.
+performs a similar function to PHP's htmlspecialchars.  It escapes the
+following characters:
+
+    " & ' < > ` { }
 
 This module uses XS for better performance, but it also provides a pure perl
 version.


### PR DESCRIPTION
Here are two suggestions for the documentation of HTML::Escape.  I think they are helpful for developers who are familiar with HTML::Entities:

- In the synopsis, I added a return value to the call.   `HTML::Entities::encode_entities` _can_ be called in void context, in which case the argument is changed in-place, whereas `escape_html` always leaves the argument intact and returns the escaped string.
- I also added the list of escaped chars, to make clear that `escape_html` does not change non-ASCII characters (which is the default escaping done by  `HTML::Entities::encode_entities`).