### PR TITLE
clean up prereqs

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -35,14 +35,11 @@ my %args = (
     },
 
     build_requires => {
-        'Devel::PPPort' => '3.20',
         'ExtUtils::CBuilder' => '0',
-        'Module::Build::Pluggable::PPPort' => '0.04',
-        'Test::More' => '0.98',
-        'Test::Requires' => '0',
     },
 
     test_requires => {
+        'Test::More' => '0.98',
     },
 
     name            => 'HTML-Escape',

--- a/META.json
+++ b/META.json
@@ -28,18 +28,12 @@
    "prereqs" : {
       "build" : {
          "requires" : {
-            "Devel::PPPort" : "3.20",
-            "ExtUtils::CBuilder" : "0",
-            "Module::Build::Pluggable::PPPort" : "0.04",
-            "Test::More" : "0.98",
-            "Test::Requires" : "0"
+            "ExtUtils::CBuilder" : "0"
          }
       },
       "configure" : {
          "requires" : {
-            "Devel::PPPort" : "3.20",
-            "Module::Build" : "0.4005",
-            "Module::Build::Pluggable::PPPort" : "0.01"
+            "Module::Build" : "0.4005"
          }
       },
       "develop" : {
@@ -57,6 +51,11 @@
             "XSLoader" : "0",
             "parent" : "0",
             "perl" : "5.008008"
+         }
+      },
+      "test" : {
+         "requires" : {
+            "Test::More" : "0.98"
          }
       }
    },

--- a/cpanfile
+++ b/cpanfile
@@ -3,15 +3,10 @@ requires 'XSLoader';
 requires 'parent';
 requires 'perl', '5.008008';
 
-on configure => sub {
-    requires 'Devel::PPPort', '3.20';
-    requires 'Module::Build::Pluggable::PPPort', '0.01';
+on build => sub {
+    requires 'ExtUtils::CBuilder';
 };
 
-on build => sub {
-    requires 'Devel::PPPort', '3.20';
-    requires 'ExtUtils::CBuilder';
-    requires 'Module::Build::Pluggable::PPPort', '0.04';
+on test => sub {
     requires 'Test::More', '0.98';
-    requires 'Test::Requires';
 };


### PR DESCRIPTION
Module::Build::Pluggable::PPPort and Devel::PPPort aren't used when building this module. It includes a ppport.h in the dist.

Test::Requires isn't used in any tests.

Test::More should be listed as a test prereq, not a build prereq.